### PR TITLE
changing target to ES6 for Typescript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
         "noImplicitAny": true,
         "removeComments": true,
         "preserveConstEnums": true,
-        "sourceMap": true
+        "sourceMap": true,
+        "target": "ES6",
     },
     "include": ["assets/**/*"]
 }


### PR DESCRIPTION
The error:

> TypeError: Class constructor Controller cannot be invoked without 'new'


Is caused when an ES5 class tries to "extend" an ES6 class. In this case, Typescript was transpiling your controller to old ES5 code. But Stimulus 3 uses pure ES6 classes (they can do that because they dropped support for IE 11). This causes an incompatability. So, you need to target ES6 explicitly.

This is something we should document - it's an easy fix, but a super difficult thing to track down.